### PR TITLE
Update the StreamID link to point to Tiles/Mainnet

### DIFF
--- a/src/container/GeoWebInterface/components/GeoWebInfo/GWInfo.jsx
+++ b/src/container/GeoWebInterface/components/GeoWebInfo/GWInfo.jsx
@@ -78,7 +78,7 @@ export default function GWInfo(props) {
         
         <p key={'Stream ID: '}>
           {'Stream ID: '}
-          <a href={`https://gateway-clay.ceramic.network/api/v0/documents/${gwInfo['ceramicUri']}`}
+          <a href={`https://tiles.ceramic.community/document/${gwInfo['ceramicUri']}`}
             target="_blank" rel="noreferrer" className={classes.typography}>
               {gwInfo['ceramicId']}
           </a>


### PR DESCRIPTION
Update link in parcel details to point to mainnet Stream on Tiles. Fixes https://github.com/Geo-Web-Project/browser/issues/21.