### PR TITLE
fix: show name and web content when media gallery is empty

### DIFF
--- a/src/container/GeoWebSystem/GWS.jsx
+++ b/src/container/GeoWebSystem/GWS.jsx
@@ -128,7 +128,7 @@ export default function GWS() {
 
       setGwContent(_parcelContent);
     }
-  }, [mediaGalleryItems]);
+  }, [basicProfileStreamManager, mediaGalleryItems]);
 
   const accessGps = () => {
     if (navigator.geolocation) {


### PR DESCRIPTION
# Description

Show the parcel name and the web content linked to the parcel when the media gallery is empty.

# Issue

fixes #43 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `main` or appropriate feature branch
- [x] My PR is opened against the `main` or appropriate feature branch

# Alert Reviewers

@codynhat @gravenp
