### PR TITLE
fix: adjust layout of unclaimed land screen

### DIFF
--- a/src/components/common/ContentFiller/Avail.jsx
+++ b/src/components/common/ContentFiller/Avail.jsx
@@ -13,7 +13,7 @@ const GWAvail = (props) => {
   const prompt2 = ` to claim it yourself (desktop recommended).`;
 
   return (
-    <div style={{ position: "absolute" }}>
+    <div className={styles["wrapper"]}>
       <div className={styles["avail-img"]} />
       <div className={styles["empty-txt"]}>
         <span className={styles["txt1"]}> {prompt1} </span>

--- a/src/components/common/ContentFiller/styles.module.css
+++ b/src/components/common/ContentFiller/styles.module.css
@@ -5,12 +5,8 @@
 }
 
 .avail-img {
-  position: absolute;
   width: 400px;
   height: 400px;
-  left: calc(50vw - 200px);
-  top: calc(50vh - 200px - 160px);
-
   background: url("/assets/available-land.png");
 }
 


### PR DESCRIPTION
# Description

Fix the layout of the image and text shown when there isn't an existing parcel claim at the user's current location.

# Issue

fixes #45 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `main` or appropriate feature branch
- [x] My PR is opened against the `main` or appropriate feature branch

# Alert Reviewers

@codynhat @gravenp
