### PR TITLE
fix: ensure only valid objects are passed to GWCanvas

### DIFF
--- a/src/container/GeoWebInterface/components/GeoWebCanvas/GWCanvas.jsx
+++ b/src/container/GeoWebInterface/components/GeoWebCanvas/GWCanvas.jsx
@@ -46,17 +46,15 @@ const GWCanvas = (props) => {
   let [modelName, setModelName] = useState("");
 
   useEffect(() => {
-    if (gwCanvasContent && gwCanvasContent[modelIndex]) {
-      const cid = gwCanvasContent[modelIndex].contentUrl.replace("ipfs://", "");
-      modelUrl = gwGateway + cid;
-      setModelUrl(modelUrl);
-      setModelName(gwCanvasContent[modelIndex]["name"]);
-    }
+    if (!gwCanvasContent) return;
+
+    const cid = gwCanvasContent[modelIndex].contentUrl.replace("ipfs://", "");
+    modelUrl = gwGateway + cid;
+    setModelUrl(modelUrl);
+    setModelName(gwCanvasContent[modelIndex]["name"]);
   }, [gwCanvasContent]);
 
   const clickLeft = () => {
-    if (gwCanvasContent === null) return;
-
     let _modelIndex = modelIndex - 1;
 
     if (_modelIndex < 0) _modelIndex = gwCanvasContent.length - 1;
@@ -69,8 +67,6 @@ const GWCanvas = (props) => {
   };
 
   const clickRight = () => {
-    if (gwCanvasContent === null) return;
-
     let _modelIndex = modelIndex + 1;
 
     if (_modelIndex > gwCanvasContent.length - 1) _modelIndex = 0;
@@ -82,12 +78,19 @@ const GWCanvas = (props) => {
     setModelName(gwCanvasContent[_modelIndex]["name"]);
   };
 
-  if (gwCanvasContent !== null) {
+  if (gwCanvasContent) {
     return (
       <div>
-        <button className={styles["clk-left"]} onClick={() => clickLeft()} />
+        {gwCanvasContent.length > 1 && (
+          <button className={styles["clk-left"]} onClick={() => clickLeft()} />
+        )}
         <ModelViewer modelRef={modelRef} url={modelUrl} />
-        <button className={styles["clk-right"]} onClick={() => clickRight()} />
+        {gwCanvasContent.length > 1 && (
+          <button
+            className={styles["clk-right"]}
+            onClick={() => clickRight()}
+          />
+        )}
 
         <ContentLabel uri={""} label={modelName} hyperlink={false} />
       </div>

--- a/src/container/GeoWebSystem/GWS.jsx
+++ b/src/container/GeoWebSystem/GWS.jsx
@@ -181,7 +181,9 @@ export default function GWS() {
           <GWContent
             gwWebContent={gwContent?.webContent ? gwContent.webContent : null}
             gwCanvasContent={
-              gwContent?.mediaContent ? gwContent.mediaContent : null
+              gwContent?.mediaContent && gwContent.mediaContent.length > 0
+                ? gwContent.mediaContent
+                : null
             }
           />
         </div>

--- a/src/helpers/gwParser.js
+++ b/src/helpers/gwParser.js
@@ -62,13 +62,16 @@ const parseMediaGalleryStream = (msg) => {
 };
 
 const parseMediaContent = (data, items) => {
-  let _mediaContent = null;
+  let _mediaContent = [];
 
   try {
     if (data.length > 0)
-      _mediaContent = data.map((itemId) => {
-        return items[itemId]?.getStreamContent();
-      });
+      for (const itemId of data) {
+        const streamContent = items[itemId]?.getStreamContent();
+        if (streamContent && Object.keys(streamContent).length > 0) {
+          _mediaContent.push(streamContent);
+        }
+      }
   } catch (e) {
     console.log(e);
   }


### PR DESCRIPTION
# Description

Sometimes Ceramic's `getStreamContent()` return an empty object and it would cause the app to crash when passed to `GWCanvas` component.
Rewrite `parseMediaContent()` of `src/helpers/gwParser.js` so that invalid media content is filtered out before being passed to `GWCanvas`.

# Issue

fixes #49 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `main` or appropriate feature branch
- [x] My PR is opened against the `main` or appropriate feature branch

# Alert Reviewers

@codynhat @gravenp
