### PR TITLE
fix: ensure modelIndex is always less than array length

### DIFF
--- a/public/assets/spinner.svg
+++ b/public/assets/spinner.svg
@@ -1,0 +1,32 @@
+<!-- By Sam Herbert (@sherb), for everyone. More @ http://goo.gl/7AJzbL -->
+<svg width="38" height="38" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient x1="8.042%" y1="0%" x2="65.682%" y2="23.865%" id="a">
+            <stop stop-color="#fff" stop-opacity="0" offset="0%"/>
+            <stop stop-color="#fff" stop-opacity=".631" offset="63.146%"/>
+            <stop stop-color="#fff" offset="100%"/>
+        </linearGradient>
+    </defs>
+    <g fill="none" fill-rule="evenodd">
+        <g transform="translate(1 1)">
+            <path d="M36 18c0-9.94-8.06-18-18-18" id="Oval-2" stroke="url(#a)" stroke-width="2">
+                <animateTransform
+                    attributeName="transform"
+                    type="rotate"
+                    from="0 18 18"
+                    to="360 18 18"
+                    dur="0.9s"
+                    repeatCount="indefinite" />
+            </path>
+            <circle fill="#fff" cx="36" cy="18" r="1">
+                <animateTransform
+                    attributeName="transform"
+                    type="rotate"
+                    from="0 18 18"
+                    to="360 18 18"
+                    dur="0.9s"
+                    repeatCount="indefinite" />
+            </circle>
+        </g>
+    </g>
+</svg>

--- a/src/container/GeoWebInterface/components/GeoWebCanvas/GWCanvas.tsx
+++ b/src/container/GeoWebInterface/components/GeoWebCanvas/GWCanvas.tsx
@@ -68,7 +68,7 @@ const GWCanvas = (props: GWCanvasProps) => {
   }, [modelIndex]);
 
   const clickLeft = () => {
-    if (!mediaGallery) return
+    if (!mediaGallery) return;
 
     setModelUrl(undefined);
     setModelName(undefined);
@@ -81,7 +81,7 @@ const GWCanvas = (props: GWCanvasProps) => {
   };
 
   const clickRight = () => {
-    if (!mediaGallery) return
+    if (!mediaGallery) return;
 
     setModelUrl(undefined);
     setModelName(undefined);
@@ -99,7 +99,13 @@ const GWCanvas = (props: GWCanvasProps) => {
         {mediaGallery.length > 1 && (
           <button className={styles["clk-left"]} onClick={() => clickLeft()} />
         )}
-        <ModelViewer modelRef={modelRef} url={modelUrl} />
+        {modelUrl ? (
+          <ModelViewer modelRef={modelRef} url={modelUrl} />
+        ) : (
+          <div className={styles["model-loading"]}>
+            <img src="/assets/spinner.svg" alt="loading" />
+          </div>
+        )}
         {mediaGallery.length > 1 && (
           <button
             className={styles["clk-right"]}

--- a/src/container/GeoWebInterface/components/GeoWebCanvas/GWCanvas.tsx
+++ b/src/container/GeoWebInterface/components/GeoWebCanvas/GWCanvas.tsx
@@ -68,23 +68,27 @@ const GWCanvas = (props: GWCanvasProps) => {
   }, [modelIndex]);
 
   const clickLeft = () => {
+    if (!mediaGallery) return
+
     setModelUrl(undefined);
     setModelName(undefined);
 
     let _modelIndex = modelIndex - 1;
 
-    if (_modelIndex < 0) _modelIndex = mediaGallery?.length ?? 0 - 1;
+    if (_modelIndex < 0) _modelIndex = mediaGallery.length - 1;
 
     setModelIndex(_modelIndex);
   };
 
   const clickRight = () => {
+    if (!mediaGallery) return
+
     setModelUrl(undefined);
     setModelName(undefined);
 
     let _modelIndex = modelIndex + 1;
 
-    if (_modelIndex > (mediaGallery?.length ?? 0) - 1) _modelIndex = 0;
+    if (_modelIndex > mediaGallery.length - 1) _modelIndex = 0;
 
     setModelIndex(_modelIndex);
   };

--- a/src/container/GeoWebInterface/components/GeoWebCanvas/styles.module.css
+++ b/src/container/GeoWebInterface/components/GeoWebCanvas/styles.module.css
@@ -46,3 +46,19 @@
   border: none;
   cursor: pointer;
 }
+
+.model-loading {
+  position: relative;
+  margin-top: 2%;
+  width: 100%;
+  height: calc(100vh - 260px);
+  background-color: lightgrey;
+}
+
+.model-loading img {
+  position: absolute;
+  width: 128px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}


### PR DESCRIPTION
# Description

When switching between models in the media gallery sometimes `modelIndex` in `GWCanvas` is set to be the same length of the `mediaGallery` array and it address to an index of an undefined element, causing `gwContent.raw.get()` to error out and the media content carousel to be stuck on the same model before the click.

This make sure `modelIndex` is not off by one and it always wrap around when it would be less than zero or equal the length of the array. 

# Issue

fixes #57 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` or appropriate feature branch
- [x] My PR is opened against the `develop` or appropriate feature branch

# Alert Reviewers

@codynhat @gravenp
