### PR TITLE
fix: support USDZ on compatible devices

### DIFF
--- a/src/container/GeoWebInterface/components/GeoWebCanvas/GWCanvas.tsx
+++ b/src/container/GeoWebInterface/components/GeoWebCanvas/GWCanvas.tsx
@@ -12,18 +12,16 @@ export type GWCanvasProps = {
   gwContent: GeoWebContent;
 };
 
-const ModelViewer = ({ url, modelRef, isUsdzModel }: any) => {
-  useEffect(() => {
-    if (!modelRef) {
-      return;
-    }
+const ModelViewer = (props: any) => {
+  const { url, modelRef, isUsdzModel } = props;
 
+  useEffect(() => {
     if (url && !isUsdzModel) {
       modelRef.current.dismissPoster();
     } else {
       modelRef.current.showPoster();
     }
-  }, [modelRef, url, isUsdzModel]);
+  }, [url, isUsdzModel]);
 
   return (
     /* @ts-ignore */

--- a/src/container/GeoWebInterface/components/GeoWebCanvas/GWCanvas.tsx
+++ b/src/container/GeoWebInterface/components/GeoWebCanvas/GWCanvas.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState, useRef } from "react";
-import GWEmpty from "../../../../components/common/ContentFiller/Empty";
-import ContentLabel from "../../../../components/common/ContentLabel/ContentLabel";
 import { GeoWebContent } from "@geo-web/content";
 import { MediaGallery, MediaObject } from "@geo-web/types";
+import GWEmpty from "../../../../components/common/ContentFiller/Empty";
+import ContentLabel from "../../../../components/common/ContentLabel/ContentLabel";
 import styles from "./styles.module.css";
 
 const gwGateway = process.env.NEXT_PUBLIC_MODEL_VIEWER_IPFS_GATEWAY;
@@ -12,16 +12,27 @@ export type GWCanvasProps = {
   gwContent: GeoWebContent;
 };
 
-const ModelViewer = (props: any) => {
-  let url = props.url;
-  let modelRef = props.modelRef;
+const ModelViewer = ({ url, modelRef, isUsdzModel }: any) => {
+  useEffect(() => {
+    if (!modelRef) {
+      return;
+    }
+
+    if (url && !isUsdzModel) {
+      modelRef.current.dismissPoster();
+    } else {
+      modelRef.current.showPoster();
+    }
+  }, [modelRef, url, isUsdzModel]);
 
   return (
-    // @ts-ignore
+    /* @ts-ignore */
     <model-viewer
       ref={modelRef}
       className={styles["gwCanvas"]}
       src={url}
+      ios-src={isUsdzModel ? url : ""}
+      reveal="manual"
       environment-image="neutral"
       shadow-intensity="1"
       ar
@@ -35,6 +46,18 @@ const ModelViewer = (props: any) => {
         <img alt="AR prompt" id="ar-prompt-img" />
       </div>
       <button id="ar-failure">AR is not tracking!</button>
+      {isUsdzModel ? (
+        <div className={styles["ar-only"]} slot="poster">
+          This model is only viewable on iPhone and iPad AR
+        </div>
+      ) : (
+        <img
+          className={styles["model-loading"]}
+          src="/assets/spinner.svg"
+          alt="loading"
+          slot="poster"
+        />
+      )}
       {/* @ts-ignore */}
     </model-viewer>
   );
@@ -42,11 +65,13 @@ const ModelViewer = (props: any) => {
 
 const GWCanvas = (props: GWCanvasProps) => {
   const { mediaGallery, gwContent } = props;
-  const [modelIndex, setModelIndex] = useState(0);
-  const modelRef = useRef();
 
+  const [modelIndex, setModelIndex] = useState(0);
   const [modelUrl, setModelUrl] = useState<string | undefined>(undefined);
   const [modelName, setModelName] = useState<string | undefined>(undefined);
+  const [isUsdzModel, setIsUsdzModel] = useState<boolean>(false);
+
+  const modelRef = useRef();
 
   useEffect(() => {
     const loadObj = async () => {
@@ -60,7 +85,12 @@ const GWCanvas = (props: GWCanvasProps) => {
         "/",
         {}
       );
-      setModelUrl(`${gwGateway}/ipfs/` + mediaObject.content.toString());
+      const _isUsdzModel = mediaObject.encodingFormat === "model/vnd.usdz+zip";
+      const fileName = _isUsdzModel ? `?filename=${mediaObject.name}.usdz` : "";
+      const contentUrl = `${gwGateway}/ipfs/${mediaObject.content.toString()}/${fileName}`;
+
+      setIsUsdzModel(_isUsdzModel);
+      setModelUrl(contentUrl);
       setModelName(mediaObject.name);
     };
 
@@ -99,13 +129,11 @@ const GWCanvas = (props: GWCanvasProps) => {
         {mediaGallery.length > 1 && (
           <button className={styles["clk-left"]} onClick={() => clickLeft()} />
         )}
-        {modelUrl ? (
-          <ModelViewer modelRef={modelRef} url={modelUrl} />
-        ) : (
-          <div className={styles["model-loading"]}>
-            <img src="/assets/spinner.svg" alt="loading" />
-          </div>
-        )}
+        <ModelViewer
+          modelRef={modelRef}
+          url={modelUrl}
+          isUsdzModel={isUsdzModel}
+        />
         {mediaGallery.length > 1 && (
           <button
             className={styles["clk-right"]}

--- a/src/container/GeoWebInterface/components/GeoWebCanvas/styles.module.css
+++ b/src/container/GeoWebInterface/components/GeoWebCanvas/styles.module.css
@@ -48,17 +48,22 @@
 }
 
 .model-loading {
-  position: relative;
-  margin-top: 2%;
-  width: 100%;
-  height: calc(100vh - 260px);
-  background-color: lightgrey;
-}
-
-.model-loading img {
-  position: absolute;
   width: 128px;
+  position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+}
+
+.ar-only {
+  background: #202333;
+  color: #ffffff;
+  border-radius: 6px;
+  padding: 8px;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.3), 0 0 8px rgba(0, 0, 0, 0.3);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate3d(-50%, -50%, 0);
+  z-index: 100;
 }

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -16,7 +16,7 @@ export default function Document() {
         <noscript>You need to enable JavaScript to run this app.</noscript>
         <script
           type="module"
-          src="https://unpkg.com/@google/model-viewer@2.0.2/dist/model-viewer.min.js"
+          src="https://unpkg.com/@google/model-viewer@2.1.1/dist/model-viewer.min.js"
           defer
         ></script>
       </Head>


### PR DESCRIPTION
# Description

When the media object in the gallery is an USDZ file (file format for Apple's AR Quick Look) show a message that inform the user the model can only be viewed in AR.

Tested on iOS 16.2, [here](https://developer.apple.com/augmented-reality/quick-look) there are some free USDZ models if needed.

# Issue

fixes #58

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` or appropriate feature branch
- [x] My PR is opened against the `develop` or appropriate feature branch

# Additional comments

With USDZ being just a zipped USD file the browser try to guess and give a .zip extension to the file returned from the gateway query.
Byte for byte is the same but the AR app doesn't render it unless it has a .usdz extension, a solution is to specify the file type by passing the file name query param in the URL.
https://github.com/web3-storage/web3.storage/issues/1122#issuecomment-1121249610

# Alert Reviewers

@codynhat @gravenp
