### PR TITLE
add: Reframe protocol when using the js-ipfs library

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -44,7 +44,13 @@ export default function Index() {
         if (ipfs.provider === "httpClient") {
           console.log("HTTP API address: " + ipfs.apiAddress);
         }
+
+        // Check if the Reframe protocol is being used
+        if (ipfs.options.reframe) {
+          console.log("Using the Reframe protocol with js-ipfs");
+        }
       }
+
 
       const _gwContent = new GeoWebContent({
         ceramic: ceramic as any,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,13 +24,10 @@ export default function Index() {
 
       const { ipfs } = await getIpfs({
         providers: [
-          // httpClient({
-          //   loadHttpClientModule: () => require("ipfs-http-client"),
-          //   apiAddress: "/ip4/127.0.0.1/tcp/5001",
-          // }),
           jsIpfs({
             loadJsIpfsModule: () => IPFSCore,
             options: {
+              reframe: true, // enable the Reframe protocol
               preload: {
                 enabled: false,
               },
@@ -38,6 +35,9 @@ export default function Index() {
           }),
         ],
       });
+
+
+
 
       if (ipfs) {
         console.log("IPFS API is provided by: " + ipfs.provider);


### PR DESCRIPTION
This PR enables the use of the Reframe protocol when interacting with the IPFS node using js-ipfs. The Reframe protocol is a delegated routing protocol that aims to improve the performance of fetching content from the IPFS network. 

To enable the Reframe protocol, the `reframe` option was added to the `options` object when creating the `jsIpfs` provider. This allows us to take advantage of the improved performance provided by the Reframe protocol when fetching content from the IPFS node.