### PR TITLE
fix: always load and animate AR prompt image on WebXR

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -37,8 +37,22 @@ model-viewer > #ar-prompt > img {
   animation: circle 4s linear infinite;
 }
 
-model-viewer > #ar-prompt-img {
-  content: url("/assets/hand.png");
+@keyframes circle {
+  from {
+    transform: translateX(-50%) rotate(0deg) translateX(50px) rotate(0deg);
+  }
+  to {
+    transform: translateX(-50%) rotate(360deg) translateX(50px) rotate(-360deg);
+  }
+}
+
+@keyframes elongate {
+  from {
+    transform: translateX(100px);
+  }
+  to {
+    transform: translateX(-100px);
+  }
 }
 
 model-viewer > #ar-failure {

--- a/src/container/GeoWebInterface/components/GeoWebCanvas/GWCanvas.tsx
+++ b/src/container/GeoWebInterface/components/GeoWebCanvas/GWCanvas.tsx
@@ -41,7 +41,7 @@ const ModelViewer = (props: any) => {
       alt=""
     >
       <div id="ar-prompt">
-        <img alt="AR prompt" id="ar-prompt-img" />
+        <img alt="AR prompt" src="assets/hand.png" />
       </div>
       <button id="ar-failure">AR is not tracking!</button>
       {isUsdzModel ? (


### PR DESCRIPTION
# Description

Always load and animate the AR prompt image on WebXR.

# Issue

fixes #68 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` or appropriate feature branch
- [x] My PR is opened against the `develop` or appropriate feature branch

# Alert Reviewers

@codynhat @gravenp
