### PR TITLE
fix: wait for network requests to complete before showing the parcel infos

### DIFF
--- a/src/container/GeoWebInterface/components/GeoWebCanvas/GWCanvas.tsx
+++ b/src/container/GeoWebInterface/components/GeoWebCanvas/GWCanvas.tsx
@@ -83,13 +83,19 @@ const GWCanvas = (props: GWCanvasProps) => {
         "/",
         {}
       );
-      const _isUsdzModel = mediaObject.encodingFormat === "model/vnd.usdz+zip";
-      const fileName = _isUsdzModel ? `?filename=${mediaObject.name}.usdz` : "";
-      const contentUrl = `${gwGateway}/ipfs/${mediaObject.content.toString()}/${fileName}`;
 
-      setIsUsdzModel(_isUsdzModel);
-      setModelUrl(contentUrl);
-      setModelName(mediaObject.name);
+      if (mediaObject) {
+        const _isUsdzModel =
+          mediaObject.encodingFormat === "model/vnd.usdz+zip";
+        const fileName = _isUsdzModel
+          ? `?filename=${mediaObject.name}.usdz`
+          : "";
+        const contentUrl = `${gwGateway}/ipfs/${mediaObject.content.toString()}/${fileName}`;
+
+        setIsUsdzModel(_isUsdzModel);
+        setModelUrl(contentUrl);
+        setModelName(mediaObject.name);
+      }
     };
 
     loadObj();

--- a/src/container/GeoWebSystem/GWS.tsx
+++ b/src/container/GeoWebSystem/GWS.tsx
@@ -30,7 +30,6 @@ export default function GWS(props: GWSProps) {
   const [parcelRoot, setParcelRoot] = useState<ParcelRoot | null>(null);
   const [basicProfile, setBasicProfile] = useState<BasicProfile | null>(null);
   const [mediaGallery, setMediaGallery] = useState<MediaGallery | null>(null);
-  const [rootCid, setRootCid] = useState<string | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -59,10 +58,12 @@ export default function GWS(props: GWSProps) {
               ownerId: accountId,
             })
           ).toString();
-          setRootCid(_rootCid);
+          const _parcelInfo = await getParcelInfo(parcelId, _rootCid); //get parcel info and meta-data
+
+          setGwInfo(_parcelInfo);
         } catch (e) {
           console.info(e);
-          setRootCid(null);
+          setGwInfo(null);
           setParcelRoot(null);
           setBasicProfile(null);
           setMediaGallery(null);
@@ -105,46 +106,11 @@ export default function GWS(props: GWSProps) {
           console.info(e);
           setBasicProfile(null);
         }
+
+        setLoading(false);
       }
     })();
-  }, [parcelId, licenseOwner, gwContent]);
-
-  useEffect(() => {
-    (async () => {
-      if (parcelId && rootCid) {
-        const _parcelInfo = await getParcelInfo(parcelId, rootCid); //get parcel info and meta-data
-        setGwInfo(_parcelInfo);
-      }
-    })();
-  }, [parcelId, rootCid]);
-
-  useEffect(() => {
-    const loadObj = async () => {
-      if (!parcelRoot?.mediaGallery || !gwContent) {
-        setMediaGallery(null);
-      } else {
-        const _mediaGallery = (await gwContent.raw.get(
-          parcelRoot.mediaGallery,
-          "/",
-          { schema: "MediaGallery" }
-        )) as MediaGallery;
-        setMediaGallery(_mediaGallery);
-      }
-
-      if (!parcelRoot?.basicProfile || !gwContent) {
-        setBasicProfile(null);
-      } else {
-        const _basicProfile = (await gwContent.raw.get(
-          parcelRoot.basicProfile,
-          "/",
-          { schema: "BasicProfile" }
-        )) as BasicProfile;
-        setBasicProfile(_basicProfile);
-      }
-    };
-
-    loadObj();
-  }, [parcelRoot]);
+  }, [parcelId, licenseOwner, gwContent, coordinate]);
 
   const accessGps = () => {
     if (navigator.geolocation) {
@@ -164,11 +130,14 @@ export default function GWS(props: GWSProps) {
   };
 
   const getParcelId = async (latitude: any, longitude: any) => {
-    const lookUpId = await getGeoId(latitude, longitude); //get root parcel id
+    const { parcelId, licenseOwner } = await getGeoId(latitude, longitude);
 
-    setParcelId(lookUpId.parcelId as any);
-    setLicenseOwner(lookUpId.licenseOwner as any);
-    setLoading(false);
+    if (!parcelId || !licenseOwner) {
+      setLoading(false);
+    }
+
+    setParcelId(parcelId as any);
+    setLicenseOwner(licenseOwner as any);
   };
 
   const GeoWeb = () => {


### PR DESCRIPTION
# Description

On page load show the loading element until we know if there is content or not.

- If there is no parcel at the coordinates requested show the "No Parcel Found" view
- If there is some error or the root CID doesn't exists show the placeholder name with no content
- If there is some content show it only after everything is loaded

# Issue

fixes #71 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` or appropriate feature branch
- [x] My PR is opened against the `develop` or appropriate feature branch

# Alert Reviewers

@codynhat @gravenp
