### PR TITLE
fix: Add geolocation permission to iframe

### DIFF
--- a/src/container/GeoWebInterface/components/GeoWebView/GWWebView.tsx
+++ b/src/container/GeoWebInterface/components/GeoWebView/GWWebView.tsx
@@ -18,7 +18,7 @@ const GWWebView = (props: GWWebViewProps) => {
         <iframe
           src={gwWebContent}
           className={styles["gwIframe"]}
-          allow="camera;gyroscope;accelerometer;magnetometer;xr-spatial-tracking;microphone;"
+          allow="geolocation;camera;gyroscope;accelerometer;magnetometer;xr-spatial-tracking;microphone;"
         />
         <ContentLabel
           uri={gwWebContent ?? ""}


### PR DESCRIPTION
# Description

Adds `geolocation` permission to iframe.

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `main` or appropriate feature branch
- [x] My PR is opened against the `main` or appropriate feature branch

# Additional comments

See https://forum.geoweb.network/t/8th-wall-integration/116
