### PR TITLE
feat: add dark mode for the gallery background

### DIFF
--- a/src/container/GeoWebInterface/components/GeoWebCanvas/styles.module.css
+++ b/src/container/GeoWebInterface/components/GeoWebCanvas/styles.module.css
@@ -70,3 +70,9 @@
   transform: translate3d(-50%, -50%, 0);
   z-index: 100;
 }
+
+@media (prefers-color-scheme: dark) {
+  .gallery {
+    background: #14161a;
+  }
+}


### PR DESCRIPTION
# Description

If the user uses a system or browser setting that show preference for a dark theme the background of the gallery is dark otherwise light grey.

# Issue

fixes #82 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` or appropriate feature branch
- [x] My PR is opened against the `develop` or appropriate feature branch

# Alert Reviewers

@codynhat @gravenp
