### PR TITLE
Remove "(desktop recommended)" from the unclaimed land page.

### DIFF
--- a/src/components/common/ContentFiller/Avail.jsx
+++ b/src/components/common/ContentFiller/Avail.jsx
@@ -4,7 +4,7 @@ export default function GWAvail() {
   const prompt1 = `No one has claimed a land parcel that includes your current location!
     Head over to `;
   const uri = "https://geoweb.land/";
-  const prompt2 = ` to claim it yourself (desktop recommended).`;
+  const prompt2 = ` to claim it yourself.`;
 
   return (
     <div className={styles["wrapper"]}>


### PR DESCRIPTION
# Description

Removed the text "(desktop recommended)" from the unclaimed land page message because the Cadastre is now mobile friendly.

# Issue

N/A

# Checklist:

- [ ] My commit message follows the Conventional Commits specification
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code
- [ ] My changes generate no new warnings
- [ ] My PR is rebased off the most recent `develop` or appropriate feature branch
- [ ] My PR is opened against the `develop` or appropriate feature branch

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it

# Alert Reviewers

@codynhat @gravenp
